### PR TITLE
Enable release-pls

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,6 +7,13 @@ on:
       - main
 
 jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Lint Git Commit Message
+        uses: wagoid/commitlint-github-action@v6
   checking:
     name: cargo check
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Release-Crate
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  # Release unpublished packages.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Create a PR with the new versions and changelog, preparing the next release.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Features:
 * Easy to integrate into projects using [embedded-hal](https://github.com/rust-embedded/embedded-hal) crates.
 * Optional [`defmt`](https://github.com/knurling-rs/defmt) support.
 
+## Contributing
+
+If you want to contribute open a Pull Request with your suggested changes and ensure that the
+integration pipeline runs.
+
+* Commits should adhere to the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+* The integration pipeline must pass.
+* Test coverage should not degrade.
+* At least one review is required
+
 ## License
 
 Licensed under either of

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default {extends: ['@commitlint/config-conventional']};


### PR DESCRIPTION
This change enforces the use the usage of Conventional Commit (https://www.conventionalcommits.org) messages and enables release-plz for release handling and changelog creation.